### PR TITLE
Adds additional colours for symbols within JSDoc comments

### DIFF
--- a/themes/OneDarkRainCoat.json
+++ b/themes/OneDarkRainCoat.json
@@ -648,6 +648,13 @@
       "settings": {
         "foreground": "#b267e6"
       }
+    },
+    {
+      "name": "Javascript JSDoc Symbol",
+      "scope": "entity.name.type.instance.jsdoc",
+      "settings": {
+        "foreground": "#E5C07B"
+      }
     }
   ]
 }

--- a/themes/OneDarkRainCoat.tmTheme
+++ b/themes/OneDarkRainCoat.tmTheme
@@ -236,7 +236,7 @@
           <string>#ABB2BF</string>
         </dict>
       </dict>
-      
+
       <dict>
         <key>name</key>
         <string>Language</string>
@@ -921,6 +921,17 @@
         <dict>
           <key>foreground</key>
           <string>#E6DB74</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Javascript JSDoc Symbol</string>
+        <key>scope</key>
+        <string>entity.name.type.instance.jsdoc</string>
+        <key>settings</key>
+        <dict>
+            <key>foreground</key>
+            <string>#E5C07B</string>
         </dict>
       </dict>
     </array>


### PR DESCRIPTION
Adds another token that will highlight JSDoc symbols in a different colour.


**With:**
![image](https://user-images.githubusercontent.com/6012242/26871893-9eb41772-4b6c-11e7-9db1-e60715fe7cc7.png)

**Without:**
![image](https://user-images.githubusercontent.com/6012242/26871991-ee50cf96-4b6c-11e7-8fed-0fc649ee70a0.png)

